### PR TITLE
Update `pyproject.toml` and workflows

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -29,11 +29,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-
       - name: Install Hatch
         uses: pypa/hatch@install
 

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -23,11 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
       - name: Install Hatch
         uses: pypa/hatch@install
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,36 +19,13 @@ permissions:
 
 # The workflow:
 jobs:
-  lint:
-    name: Lint with Ruff (Py${{ matrix.python-version }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.12", "3.13"]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install Hatch
-        uses: pypa/hatch@install
-
-      - name: Lint with Ruff
-        run: |
-          hatch run lint
-
   test:
-    name: Test with Py${{ matrix.python-version }} on ${{ matrix.os }}
+    name: Test on ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        python-version: ["3.12", "3.13"]
 
     runs-on: ${{ matrix.os }}-latest
     steps:
@@ -58,26 +35,21 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
       - name: Install Hatch
         uses: pypa/hatch@install
 
       - name: Test
-        run: hatch run coverage run -m pytest
+        run: hatch run test-and-report
 
       - name: Rename the coverage file
-        run: mv .coverage .coverage.${{ matrix.python-version }}.${{ matrix.os }}
+        run: mv .coverage .coverage.${{ matrix.os }}
 
       - name: Store coverage files
         uses: actions/upload-artifact@v4
         with:
           include-hidden-files: true
-          name: coverage-${{ matrix.python-version }}-${{ matrix.os }}
-          path: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
+          name: coverage-${{ matrix.os }}
+          path: .coverage.${{ matrix.os }}
 
   report-coverage:
     name: Generate the coverage report
@@ -86,11 +58,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
 
       - name: Download coverage files
         uses: actions/download-artifact@v4
@@ -114,6 +81,6 @@ jobs:
           smokeshow upload ./htmlcov
         env:
           SMOKESHOW_GITHUB_STATUS_DESCRIPTION: Coverage {coverage-percentage}
-          SMOKESHOW_GITHUB_COVERAGE_THRESHOLD: 50
+          SMOKESHOW_GITHUB_COVERAGE_THRESHOLD: 95
           SMOKESHOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SMOKESHOW_GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,19 +22,19 @@ dependencies = [
 ]
 authors = [
     { name = 'Sina Atalay', email = 'dev@atalay.biz' },
-    { name = "Kentaro Hanson", email = "example@example.com" },
-    { name = "Sacha Escudier", email = "example@example.com" },
+    { name = "Kentaro Hanson" },
+    { name = "Sacha Escudier" },
 ]
 name = 'fastfem'
 description = 'A Python package for solving PDEs with the finite element method and automatic differentiation'
 license = "Apache-2.0"
 readme = "README.md"
-requires-python = '>=3.12'
+requires-python = '>=3.12,<3.13'
 classifiers = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: Education",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
+    # "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ] # Go to https://pypi.org/classifiers/ to see all classifiers
@@ -50,12 +50,13 @@ Changelog = 'https://fastfem.com/changelog'
 # ======================================================================================
 
 [tool.hatch.envs.default]
+installer = "uv"
+python = "3.12"
 # Dependencies to be installed in the `default` virtual environment.
 dependencies = [
     "ruff",     # to lint the code
     "black",    # to format the code
     "ipython",  # for ipython shell
-    "isort",    # to sort the imports
     "pyright",  # to check the types
     "pytest",   # to run the tests
     "coverage", # to measure the test coverage
@@ -63,20 +64,20 @@ dependencies = [
 path = ".venv"
 [tool.hatch.envs.default.scripts]
 # Format all the code with `black`:
-format = "black fastfem && black tests" # hatch run format
+format = "ruff check --fix && black fastfem tests" # hatch run format
 # Lint the code with `ruff`:
 lint = "ruff check fastfem && ruff check tests" # hatch run lint
-# Sort the imports with `isort`:
-sort = "isort fastfem && isort tests" # hatch run sort
 # Check types with `pyright`:
-check-types = "pyright fastfem && pyright tests" # hatch run check-types
+check-types = "pyright fastfem tests" # hatch run check-types
 # Run the tests:
-tests = "pytest" # hatch run tests
+test = "pytest" # hatch run tests
 # Run the tests and generate the coverage report as HTML:
-tests-and-coverage = "coverage run -m pytest && coverage report && coverage html --show-contexts" # hatch run tests-and-coverage
+test-and-report = "coverage run -m pytest && coverage report && coverage html --show-contexts" # hatch run tests-and-coverage
 
 
 [tool.hatch.envs.docs]
+installer = "uv"
+python = "3.12"
 # Dependencies to be installed in the `docs` virtual environment.
 dependencies = [
     "mkdocs-material==9.5.39",     # docs engine and theme
@@ -98,6 +99,12 @@ serve = "mkdocs serve" # hatch run docs:serve
 
 [tool.ruff]
 output-format = "github"
+line-length = 88
+
+[tool.ruff.format]
+docstring-code-format = true
+
+[tool.ruff.lint]
 # extend-select = [
 #     "B",   # flake8-bugbear
 #     "I",   # isort
@@ -125,9 +132,10 @@ output-format = "github"
 # ignore = [
 #     "PLR",    # Design related pylint codes
 #     "ISC001", # Conflicts with formatter
+#     "UP007",  # Allow `Optional` type
+#     "PGH003", # Allow type: ignore comments
 # ]
-# flake8-unused-arguments.ignore-variadic-names = true
-# isort.required-imports = ["from __future__ import annotations"]
+flake8-unused-arguments.ignore-variadic-names = true
 
 [tool.black]
 line-length = 88 # maximum line length
@@ -135,9 +143,6 @@ preview = true # to allow enable-unstable-feature
 enable-unstable-feature = [
     "string_processing",
 ] # to break strings into multiple lines
-
-[tool.isort]
-profile = "black"
 
 [tool.pyright]
 # No options are needed for `pyright` for now.
@@ -156,7 +161,6 @@ exclude_lines = [
     "return __all__",
     "raise NotImplementedError",
 ]
-
 
 [tool.pytest.ini_options]
 addopts = [


### PR DESCRIPTION
This PR closes #29.

Also, it turns out `pyvista==0.44.2` (the latest version as of today) doesn't support Python 3.13 (https://github.com/pyvista/pyvista/issues/6857). Therefore, we can't support Python 3.13 at this time. I was wondering why the tests were working for 3.13, but I realized they weren't running in Python 3.13, only 3.12. I fixed the workflows accordingly.

Also, I added new Ruff settings in `[tool.ruff]` but commented them out because there are many linting issues right now. We should have a look when we merge everything before the Dean's date (#42).